### PR TITLE
htaccess: redirect .git to root

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,1 @@
+RedirectMatch "^/.git" https://curl.dev/


### PR DESCRIPTION
It is harmless but it is too much of a honeypot for "security researchers" that can't help themselves to keep reporting this as a security problem.